### PR TITLE
fix: change push command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Deta Space Deployment Github Action
-        uses: neobrains/space-deployment-github-action@v0.3
+        uses: neobrains/space-deployment-github-action@v0.5
         with:
           access_token: ${{ secrets.ACCESS_TOKEN }}
           project_id: ${{ secrets.PROJECT_ID }}

--- a/action.yml
+++ b/action.yml
@@ -54,15 +54,17 @@ runs:
       shell: script -q -e -c "bash {0}"
       run: |
         cd ${{ inputs.project_directory }}
-        space push --id "${{ inputs.project_id }}"
+        space link --id "${{ inputs.project_id }}"
+        space push
 
     - name: Create a release on Deta Space
       if: ${{ inputs.space_release == 'true' }}
       shell: script -q -e -c "bash {0}"
       run: |
         cd ${{ inputs.project_directory }}
+        space link --id "${{ inputs.project_id }}"
         if [[ ${{ inputs.list_on_discovery }} == true ]]; then
-          space release --id "${{ inputs.project_id }}" --version "${{ inputs.release_version }}" --listed --confirm
+          space release --version "${{ inputs.release_version }}" --listed --confirm
         else
-          space release --id "${{ inputs.project_id }}" --version "${{ inputs.release_version }}" --confirm
+          space release --version "${{ inputs.release_version }}" --confirm
         fi


### PR DESCRIPTION
Based on the writing date of the current article, we have confirmed that the space push --id command does not work in the deta space cli.

```
space push --id ""
Error: project is not initialized. run `space new` to initialize a new project
Usage:
  space push [flags]

Flags:
  -d, --dir string   src of project to push (default "./")
  -h, --help         help for push
  -i, --id string    project id of project to push
      --open         open builder instance/project in browser after push
      --skip-logs    skip following logs after push
  -t, --tag string   tag to identify this push
```

So I added the space link command to the code.

Please confirm.