### PR TITLE
cleanup: use `bash` as shell and simplify adding the CLI directory to system path

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -46,12 +46,12 @@ runs:
       shell: bash
       run: |
         curl -fsSL https://get.deta.dev/space-cli.sh | sh
-        echo '/home/runner/.detaspace/bin' >> $GITHUB_PATH
+        echo "$HOME/.detaspace/bin" >> $GITHUB_PATH
         echo "SPACE_ACCESS_TOKEN=${{ inputs.access_token }}" >> $GITHUB_ENV
 
     - name: Push changes to Deta Space
       if: ${{ inputs.space_push == 'true' }}
-      shell: script -q -e -c "bash {0}"
+      shell: bash
       run: |
         cd ${{ inputs.project_directory }}
         space link --id "${{ inputs.project_id }}"
@@ -59,7 +59,7 @@ runs:
 
     - name: Create a release on Deta Space
       if: ${{ inputs.space_release == 'true' }}
-      shell: script -q -e -c "bash {0}"
+      shell: bash
       run: |
         cd ${{ inputs.project_directory }}
         space link --id "${{ inputs.project_id }}"


### PR DESCRIPTION
The current Deta Space CLI works with non-interactive shell environments, such as those used in GitHub and GitLab CI/CD workflows. So changed the shell to plain `bash` from `script -q -e -c "bash {0}"`.